### PR TITLE
Update PbStructureViewBuilderProvider.java

### DIFF
--- a/src/protobuf/structureView/PbStructureViewBuilderProvider.java
+++ b/src/protobuf/structureView/PbStructureViewBuilderProvider.java
@@ -1,11 +1,13 @@
 package protobuf.structureView;
 
+import com.intellij.openapi.editor.Editor;
 import com.intellij.ide.structureView.StructureViewBuilder;
 import com.intellij.ide.structureView.StructureViewModel;
 import com.intellij.ide.structureView.TreeBasedStructureViewBuilder;
 import com.intellij.lang.PsiStructureViewFactory;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Nikolay Matveev
@@ -16,7 +18,7 @@ public class PbStructureViewBuilderProvider implements PsiStructureViewFactory {
         return new TreeBasedStructureViewBuilder() {
             @NotNull
             @Override
-            public StructureViewModel createStructureViewModel() {
+            public StructureViewModel createStructureViewModel(@Nullable Editor editor) {
                 return new PbStructureViewModel(psiFile);
             }
         };


### PR DESCRIPTION
public StructureViewModel TreeBasedStructureViewBuilder.createStructureViewModel() had declared as @Deprecated and was removed in Feb 2015, so in current IDEA builds the structure view for .proto files is not shown