### PR TITLE
fix: Use ';' separator for additional proto paths

### DIFF
--- a/src/protobuf/compiler/PbCompiler.java
+++ b/src/protobuf/compiler/PbCompiler.java
@@ -58,6 +58,7 @@ public class PbCompiler implements SourceGeneratingCompiler {
     private static final String PROTOC_LINUX = "protoc";
     private static final String PROTOC_MAC = "protoc";
 
+    private static final String DEFAULT_PROTO_SOURCE_ROOT = "src/main/proto";
 
     private static final Matcher ERROR_IN_LINE_MATCHER = Pattern.compile("[^:]*:[0-9]*:[0-9]*:.*").matcher("");
     private static final Matcher ERROR_IN_FILE_MATCHER = Pattern.compile("[^:]*:[^:]*").matcher("");
@@ -149,6 +150,14 @@ public class PbCompiler implements SourceGeneratingCompiler {
                             }
                             for (String addtionalProtoPath : getModuleAdditionalProtoPaths(item)) {
                                 compilerCommand.append(" --proto_path=").append(addtionalProtoPath);
+                            }
+                            // Add the default proto source root for the module if the directory exists.
+                            VirtualFile moduleFile = item.getModule().getModuleFile();
+                            if (moduleFile != null) {
+                                VirtualFile protoSourceRoot = moduleFile.getParent().findFileByRelativePath(DEFAULT_PROTO_SOURCE_ROOT);
+                                if ((protoSourceRoot != null) && protoSourceRoot.isDirectory()) {
+                                    compilerCommand.append(" --proto_path=").append(protoSourceRoot.getPath());
+                                }
                             }
                             compilerCommand.append(" --java_out=").append(outputPath);
                             compilerCommand.append(" ").append(item.getPath());

--- a/src/protobuf/settings/facet/ProtobufFacetEditor.java
+++ b/src/protobuf/settings/facet/ProtobufFacetEditor.java
@@ -79,7 +79,7 @@ public class ProtobufFacetEditor extends FacetEditorTab {
         for (int i = 0; i < splitPaths.length; i++) {
             splitPaths[i] = FileUtil.toSystemIndependentName(splitPaths[i]);
         }
-        return StringUtil.join(splitPaths);
+        return StringUtil.join(splitPaths, ";");
     }
 
     @Override


### PR DESCRIPTION
A previous commit failed to add the ';' separator when merging multiple
proto paths.
