### PR TITLE
Add a new option 'Generate Nano Protobuf'

### DIFF
--- a/resources/messages/PbBundle.properties
+++ b/resources/messages/PbBundle.properties
@@ -65,6 +65,7 @@ compiler.validate.error.title=Protocol Buffers compiler
 compiler.validate.error.unsupported.os=Plugin compiler does not support this OS.
 compiler.validate.error.path.to.protoc=Could not find 'protoc' at path "{0}". Check the compiler configuration.
 compiler.validate.error.protoc.not.executable=The 'protoc' compiler file is not executable.
+compiler.validate.error.protoc.javaout.nano.not.supported=Module {0} uses nano protobuf but the 'protoc' compiler doesn't support --javanano_out option.
 compiler.validate.error.output.source.directory.not.exists="{0}" does not exist.
 compiler.validate.error.output.source.directory.not.set=The output source directory for module "{0}" has not been set.
 compiler.validate.error.output.source.directory.not.created=Could not created the output source directory "{0}" for module "{1}". Please check your configuration and/or file permissions.

--- a/src/protobuf/settings/facet/ProtobufDefaultFacetSettingsEditor.java
+++ b/src/protobuf/settings/facet/ProtobufDefaultFacetSettingsEditor.java
@@ -42,13 +42,14 @@ public class ProtobufDefaultFacetSettingsEditor extends DefaultFacetSettingsEdit
     @Override
     public boolean isModified() {
         return configuration.isCompilationEnabled() != commonSettingsEditor.getEnableCompilationCheckbox().isSelected() ||
-                !configuration.getCompilerOutputPath().equals(commonSettingsEditor.getProtobufCompilerOutputPathField().getText());
+                configuration.isGenerateNanoProto() != commonSettingsEditor.getGenerateNanoProtoCheckBox().isSelected() ||
+                !configuration.getCompilerOutputPath().equals(commonSettingsEditor.getProtobufCompilerOutputPathField().getText()) ||
+                !configuration.getAdditionalProtoPaths().equals(commonSettingsEditor.getProtobufAdditionalProtoPaths().getText());
     }
 
     @Override
     public void apply() throws ConfigurationException {
         boolean isCompilationCheckboxEnabled = commonSettingsEditor.getEnableCompilationCheckbox().isSelected();
-        configuration.setIsCompilationEnabled(isCompilationCheckboxEnabled);
         if (isCompilationCheckboxEnabled && !configuration.isCompilationEnabled()) {
             CompilerManager compilerManager = CompilerManager.getInstance(project);
             compilerManager.addCompilableFileType(PbFileType.PROTOBUF_FILE_TYPE);
@@ -61,6 +62,8 @@ public class ProtobufDefaultFacetSettingsEditor extends DefaultFacetSettingsEdit
             }
         }
 
+        configuration.setIsCompilationEnabled(isCompilationCheckboxEnabled);
+        configuration.setGenerateNanoProto(commonSettingsEditor.getGenerateNanoProtoCheckBox().isSelected());
         configuration.setCompilerOutputPath(commonSettingsEditor.getProtobufCompilerOutputPathField().getText().trim());
         configuration.setCompilerOutputPath(commonSettingsEditor.getProtobufAdditionalProtoPaths().getText().trim());
     }
@@ -68,6 +71,7 @@ public class ProtobufDefaultFacetSettingsEditor extends DefaultFacetSettingsEdit
     @Override
     public void reset() {
         commonSettingsEditor.getEnableCompilationCheckbox().setSelected(configuration.isCompilationEnabled());
+        commonSettingsEditor.getGenerateNanoProtoCheckBox().setSelected(configuration.isGenerateNanoProto());
         commonSettingsEditor.getProtobufCompilerOutputPathField().setText(configuration.getCompilerOutputPath());
         commonSettingsEditor.getProtobufAdditionalProtoPaths().setText(configuration.getAdditionalProtoPaths());
     }

--- a/src/protobuf/settings/facet/ProtobufFacetCommonSettingsEditor.form
+++ b/src/protobuf/settings/facet/ProtobufFacetCommonSettingsEditor.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="bdbef" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="bdbef" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="5" left="5" bottom="5" right="5"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -25,9 +25,18 @@
               <thirdStateEnabled value="false"/>
             </properties>
           </component>
+          <component id="39f9" class="com.intellij.util.ui.ThreeStateCheckBox" binding="generateNanoProtoCheckBox">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Generate nano proto"/>
+              <thirdStateEnabled value="false"/>
+            </properties>
+          </component>
           <component id="81a1c" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="protobufCompilerOutputPath">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>
@@ -35,7 +44,7 @@
           </component>
           <component id="ed268" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="messages/PbBundle" key="compiler.configurable.source.directory"/>
@@ -43,7 +52,7 @@
           </component>
           <component id="a2f86" class="javax.swing.JLabel">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="messages/PbBundle" key="facet.protobuf.additional.proto.paths.text"/>
@@ -51,7 +60,7 @@
           </component>
           <component id="c8a48" class="javax.swing.JTextField" binding="protobufAdditionalProtoPaths">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
             </constraints>

--- a/src/protobuf/settings/facet/ProtobufFacetCommonSettingsEditor.java
+++ b/src/protobuf/settings/facet/ProtobufFacetCommonSettingsEditor.java
@@ -13,6 +13,7 @@ public class ProtobufFacetCommonSettingsEditor extends JComponent {
 
     private JPanel mainPanel;
     private ThreeStateCheckBox enableCompilationCheckBox;
+    private ThreeStateCheckBox generateNanoProtoCheckBox;
     private TextFieldWithBrowseButton protobufCompilerOutputPath;
     private JTextField protobufAdditionalProtoPaths;
 
@@ -26,6 +27,10 @@ public class ProtobufFacetCommonSettingsEditor extends JComponent {
 
     public ThreeStateCheckBox getEnableCompilationCheckbox() {
         return enableCompilationCheckBox;
+    }
+
+    public ThreeStateCheckBox getGenerateNanoProtoCheckBox() {
+        return generateNanoProtoCheckBox;
     }
 
     public TextFieldWithBrowseButton getProtobufCompilerOutputPathField() {

--- a/src/protobuf/settings/facet/ProtobufFacetConfiguration.java
+++ b/src/protobuf/settings/facet/ProtobufFacetConfiguration.java
@@ -26,6 +26,7 @@ import org.jdom.Element;
 public class ProtobufFacetConfiguration implements FacetConfiguration, PersistentStateComponent<ProtobufFacetSettings> {
 
     private boolean compilationEnabled = true;
+    private boolean generateNanoProto = false;
     private String compilerOutputPath = "";
     private String additionalProtoPaths = "";
 
@@ -48,6 +49,7 @@ public class ProtobufFacetConfiguration implements FacetConfiguration, Persisten
     public ProtobufFacetSettings getState() {
         ProtobufFacetSettings settings = new ProtobufFacetSettings();
         settings.COMPILE_PROTO = compilationEnabled;
+        settings.GENERATE_NANO_PROTO = generateNanoProto;
         settings.COMPILER_OUTPUT_SOURCE_DIRECTORY = compilerOutputPath;
         settings.COMPILER_ADDITIONAL_PROTO_PATHS = additionalProtoPaths;
         return settings;
@@ -56,6 +58,7 @@ public class ProtobufFacetConfiguration implements FacetConfiguration, Persisten
     @Override
     public void loadState(ProtobufFacetSettings settings) {
         compilationEnabled = settings.COMPILE_PROTO;
+        generateNanoProto = settings.GENERATE_NANO_PROTO;
         compilerOutputPath = settings.COMPILER_OUTPUT_SOURCE_DIRECTORY;
         additionalProtoPaths = settings.COMPILER_ADDITIONAL_PROTO_PATHS;
     }
@@ -66,6 +69,14 @@ public class ProtobufFacetConfiguration implements FacetConfiguration, Persisten
 
     public void setIsCompilationEnabled(boolean value) {
         compilationEnabled = value;
+    }
+
+    public boolean isGenerateNanoProto() {
+        return generateNanoProto;
+    }
+
+    public void setGenerateNanoProto(boolean value) {
+        generateNanoProto = value;
     }
 
     public String getCompilerOutputPath() {

--- a/src/protobuf/settings/facet/ProtobufFacetEditor.java
+++ b/src/protobuf/settings/facet/ProtobufFacetEditor.java
@@ -35,6 +35,7 @@ public class ProtobufFacetEditor extends FacetEditorTab {
         final Module module = editorContext.getModule();
 
         commonSettingsEditor.getEnableCompilationCheckbox().setSelected(configuration.isCompilationEnabled());
+        commonSettingsEditor.getGenerateNanoProtoCheckBox().setSelected(configuration.isGenerateNanoProto());
         commonSettingsEditor.getProtobufCompilerOutputPathField().setText(configuration.getCompilerOutputPath());
         commonSettingsEditor.getProtobufCompilerOutputPathField().addBrowseFolderListener(project, new CompilerOutputBrowseFolderActionListener(project, module, commonSettingsEditor.getProtobufCompilerOutputPathField()));
         commonSettingsEditor.getProtobufAdditionalProtoPaths().setText(configuration.getAdditionalProtoPaths());
@@ -59,10 +60,12 @@ public class ProtobufFacetEditor extends FacetEditorTab {
     @Override
     public boolean isModified() {
         boolean compilationEnabled = commonSettingsEditor.getEnableCompilationCheckbox().isSelected();
+        boolean generateNanoProto = commonSettingsEditor.getGenerateNanoProtoCheckBox().isSelected();
         String outputPath = commonSettingsEditor.getProtobufCompilerOutputPathField().getText().trim();
         String additionalProtoPaths = commonSettingsEditor.getProtobufAdditionalProtoPaths().getText().trim();
 
         return ((configuration.isCompilationEnabled() != compilationEnabled) ||
+            (configuration.isGenerateNanoProto() != generateNanoProto) ||
             (!Comparing.equal(configuration.getCompilerOutputPath(), FileUtil.toSystemIndependentName(outputPath))) ||
             (!Comparing.equal(configuration.getAdditionalProtoPaths(), toSystemIndependentPaths(additionalProtoPaths))));
     }
@@ -70,6 +73,7 @@ public class ProtobufFacetEditor extends FacetEditorTab {
     @Override
     public void apply() throws ConfigurationException {
         configuration.setIsCompilationEnabled(commonSettingsEditor.getEnableCompilationCheckbox().isSelected());
+        configuration.setGenerateNanoProto(commonSettingsEditor.getGenerateNanoProtoCheckBox().isSelected());
         configuration.setCompilerOutputPath(FileUtil.toSystemIndependentName(commonSettingsEditor.getProtobufCompilerOutputPathField().getText().trim()));
         configuration.setAdditionalProtoPaths(toSystemIndependentPaths(commonSettingsEditor.getProtobufAdditionalProtoPaths().getText()));
     }
@@ -94,6 +98,10 @@ public class ProtobufFacetEditor extends FacetEditorTab {
 
     public JCheckBox getEnableCompilationCheckbox() {
         return commonSettingsEditor.getEnableCompilationCheckbox();
+    }
+
+    public JCheckBox getGenerateNanoProtoCheckbox() {
+        return commonSettingsEditor.getGenerateNanoProtoCheckBox();
     }
 
     public TextFieldWithBrowseButton getProtobufCompilerOutputPathField() {

--- a/src/protobuf/settings/facet/ProtobufFacetSettings.java
+++ b/src/protobuf/settings/facet/ProtobufFacetSettings.java
@@ -9,6 +9,9 @@ public class ProtobufFacetSettings {
     // Is compilation of .proto files enabled?
     public boolean COMPILE_PROTO = true;
 
+    // Do we generate nano protobuf instead?
+    public boolean GENERATE_NANO_PROTO = false;
+
     // The directory where the files resulting from protoc invocation will be created.
     public String COMPILER_OUTPUT_SOURCE_DIRECTORY = "";
 

--- a/src/protobuf/settings/facet/ProtobufMultipleFacetSettingsEditor.java
+++ b/src/protobuf/settings/facet/ProtobufMultipleFacetSettingsEditor.java
@@ -33,6 +33,14 @@ public class ProtobufMultipleFacetSettingsEditor extends MultipleFacetSettingsEd
             }
         });
 
+        // Bind to the generate nano proto checkbox.
+        helper.bind(commonSettingsEditor.getGenerateNanoProtoCheckBox(), editors, new NotNullFunction<FacetEditor, JCheckBox>() {
+            @NotNull
+            public JCheckBox fun(final FacetEditor facetEditor) {
+                return (facetEditor.getEditorTab(ProtobufFacetEditor.class)).getGenerateNanoProtoCheckbox();
+            }
+        });
+
         // Bind to the output source directory text field.
         helper.bind(commonSettingsEditor.getProtobufCompilerOutputPathField().getTextField(), editors, new NotNullFunction<FacetEditor, JTextField>() {
             @NotNull


### PR DESCRIPTION
JavaNano is a special code generator and runtime library designed
specially for resource-restricted systems, like Android, officially made
by Google: https://github.com/google/protobuf/tree/master/javanano

This commit adds a new checkbox in the facet settings to enable or disable
generating nano protobuf.