### PR TITLE
Update plugin.xml for 2017.1 compatibility 

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>com.nmatveev.idea-plugin-protobuf</id>
     <vendor>Strintec</vendor>
     <name>Google Protocol Buffers support</name>
-    <version>0.5.10</version>
+    <version>0.6.0</version>
     <category>Custom Languages</category>
     <description>
         <![CDATA[


### PR DESCRIPTION
Make the plugin compatible with 2017.1 by recompiling with a incremented version number, would probably also require updating associated documentation.